### PR TITLE
fix: support both NIF 2.16 and 2.17 in precompiled workflow

### DIFF
--- a/.github/workflows/precompiled-nifs.yml
+++ b/.github/workflows/precompiled-nifs.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nif: ["2.16"]
+        nif: ["2.16", "2.17"]
         job:
           - { target: x86_64-apple-darwin, os: macos-13 }
           # Use native Apple Silicon runner for aarch64-apple-darwin to avoid cross-compilation issues


### PR DESCRIPTION
## Summary
- Adds both NIF 2.16 and 2.17 to the precompiled workflow build matrix
- Resolves 404 download errors when fetching precompiled binaries
- Supports users with different Erlang/OTP versions

## Test plan
- [ ] Workflow builds successfully for both NIF versions
- [ ] Precompiled binaries are available for download

🤖 Generated with [Claude Code](https://claude.ai/code)