### PR TITLE
chore: upgrade toolchain to latest Elixir/Erlang/Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,15 +87,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: "1.18.3"
-            otp: "27.2"
+          - elixir: "1.20.0"
+            otp: "29.0"
             warnings_as_errors: true
-          - elixir: "1.17.3"
-            otp: "27.2"
-          - elixir: "1.17.3"
-            otp: "26.2"
-          - elixir: "1.16.3"
-            otp: "26.2"
+          - elixir: "1.19.5"
+            otp: "28.4"
+          - elixir: "1.18.4"
+            otp: "27.3.4.4"
     steps:
       - uses: actions/checkout@v5
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.18.3
-erlang 27.2
-rust 1.88.0
+elixir 1.20.0-otp-29
+erlang 29.0
+rust 1.93.1

--- a/lib/dprint_markdown_formatter.ex
+++ b/lib/dprint_markdown_formatter.ex
@@ -92,8 +92,6 @@ defmodule DprintMarkdownFormatter do
 
   @behaviour Mix.Tasks.Format
 
-  require Logger
-
   alias DprintMarkdownFormatter.AstProcessor
   alias DprintMarkdownFormatter.Config
   alias DprintMarkdownFormatter.Error


### PR DESCRIPTION
## Summary
- Bump `.tool-versions` to **Elixir 1.20.0 / OTP 29.0 / Rust 1.93.1**.
- Update CI `matrix-test` to the three latest Elixir/OTP pairs (1.20.0/29.0, 1.19.5/28.4, 1.18.4/27.3.4.4); drop EOL 1.16/1.17 & OTP 26.
- Remove an unused `require Logger` newly flagged by Elixir 1.20's unused-require warning.

## Why
The `v0.7.0` hex publish failed: the Publish job's precompiled-NIF download from the GitHub release CDN hit an OTP `:ssl` `key_usage_mismatch` fatal alert. This is the OTP 27.1.3–27.2 regression ([erlang/otp#9208](https://github.com/erlang/otp/issues/9208), fixed by [#9286](https://github.com/erlang/otp/pull/9286)). The repo was pinned to OTP 27.2 — squarely in the broken window. Moving to OTP 29 resolves it.

## Test plan
- [x] `mix compile --warnings-as-errors` clean on Elixir 1.20.0 / OTP 29.0
- [x] `mix test` → 142 passed, 1 skipped on Elixir 1.20.0 / OTP 29.0
- [ ] CI matrix green across all three pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)